### PR TITLE
Improve performance of question list page

### DIFF
--- a/codewof/programming/filters.py
+++ b/codewof/programming/filters.py
@@ -1,10 +1,23 @@
 import django_filters
-from programming.models import Question, DifficultyLevel
+from programming.models import (
+    Question,
+    DifficultyLevel,
+    ProgrammingConcepts,
+    QuestionContexts,
+)
 from django.db.models import Q
+
 
 class QuestionFilter(django_filters.FilterSet):
     # contexts=django_filters.filters.CharFilter(method="contexts_filter")
-    
+
+    concepts = django_filters.filters.ModelMultipleChoiceFilter(
+        queryset=ProgrammingConcepts.objects.prefetch_related('parent')
+    )
+    contexts = django_filters.filters.ModelMultipleChoiceFilter(
+        queryset=QuestionContexts.objects.prefetch_related('parent')
+    )
+
     class Meta:
         model = Question
         fields = {'difficulty_level', 'concepts', 'contexts'}

--- a/codewof/programming/views.py
+++ b/codewof/programming/views.py
@@ -56,7 +56,9 @@ class QuestionListView(LoginRequiredMixin, FilterView):
             .select_related('difficulty_level')
             .prefetch_related(
                 'concepts',
+                'concepts__parent',
                 'contexts',
+                'contexts__parent',
             )
             .annotate(completed=Exists(user_successful_attempt_subquery))
         )


### PR DESCRIPTION
This pull request greatly improves the performance of the question list page, in several ways:
1. It removes iterating over questions to mark completion, and does it via a query annotation. This took the number of queries from 158 to 25.
2. Every time the `__str__` method is called on a concept or context, another query is made if the object has a parent. Adding these attributes to the existing `prefetch_related` reduces the queries from 25 to 24, however the search filter still duplicates these queries.
3. Modifying the `QuestionFilter` filterset to prefetch parents, for the same reason as the previous point. This reduces the number of queries from 24 to 15.

These changes greatly reduce the number of queries, and therefore the CPU time to render the page.

Possible next steps to improve performance:
- Contexts and concepts models could be altered to reduce the need to prefetch every time:
    - Could be done by adding a second name attribute that includes the parent name, and `__str__` uses this if available.
    - Could be done by modifying the object manager to always prefetch the parents.
- Paginate the question page since (tracked at https://github.com/uccser/codewof/issues/382)